### PR TITLE
Remove calc() from @media query

### DIFF
--- a/src/components/ViewContent/ViewContent.scss
+++ b/src/components/ViewContent/ViewContent.scss
@@ -6,13 +6,13 @@
     padding: 1rem 0;
     width: 100%;
 
-    @media screen and (max-width: calc(600px + 2rem)) {
+    @media screen and (max-width: 632px) {
         margin-left: 1rem;
         margin-right: 1rem;
         width: calc(100% - 2rem);
     }
 
-    &.ViewContent__squish {
+    &__squish {
         height: 100%;
         padding: 0;
     }


### PR DESCRIPTION
There might be a way to do it with Sass, but the standard CSS calc() function does not work in a @media query.

Fixes #36